### PR TITLE
Sport: fix transmitted value for GPS heading.

### DIFF
--- a/src/sport.cpp
+++ b/src/sport.cpp
@@ -424,9 +424,6 @@ void sendOneSport(uint8_t idx){  // fill one frame and send it
             uintValue = ((  ((((uint32_t)( intValue < 0 ? -intValue : intValue)) / 10 ) * 6 )/ 10 ) & 0x3FFFFFFF ) ;
             if(intValue < 0) uintValue |= 0x40000000;
             break;
-        case HEADING:
-            uintValue =  intValue / 1000 ; // convert from degree * 100000 to degree * 100
-            break;
         case GROUNDSPEED:  // to do : test for the right value
             //uintValue =  ( ((uint32_t) uintValue) * 36 )  ; // convert cm/s in 1/100 of km/h (factor = 3.6)
             uintValue =  ( ((uint32_t) uintValue) * 700 ) / 36 ; // convert cm/s in 1/1000 of knots (factor = 19.44)
@@ -482,7 +479,7 @@ void sendOneSport(uint8_t idx){  // fill one frame and send it
         for (uint8_t j = 0 ; j < sportLength ; j++ ){
             printf(" %02X" , sportTxBuffer[j]);
         }
-        printf("/n");    
+        printf("\n");    
     }
     //sleep_us(100) ;
     sport_uart_rx_program_stop(sportPio, sportSmRx, config.pinTlm); // stop receiving


### PR DESCRIPTION
Remove division by 1000, because HEADING frame value is already in centi-degrees (division by 1000 already happens in GPS driver at https://github.com/mstrens/oXs_on_RP2040/blob/8a4ef64adb4ba2b69764f8e65827d91974815df9/src/gps.cpp#L510).